### PR TITLE
Add .ci-operator.yaml for CI build root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.25-openshift-4.22


### PR DESCRIPTION
## Summary
- Add `.ci-operator.yaml` configuration file to specify the CI build root image
- Uses `rhel-9-release-golang-1.25-openshift-4.22` image matching the Go 1.25 version in go.mod

## Test plan
- [ ] Verify CI jobs pick up the new build root image configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)