### PR TITLE
CNTRLPLANE-2602: add release operator label to OCP Dockerfile

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -5,4 +5,5 @@ RUN CGO_ENABLED=0 go build -mod=vendor -tags nthlinux -ldflags="-s -w" -o /go/bi
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=builder /go/bin/node-termination-handler /usr/bin/
+LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/node-termination-handler"]


### PR DESCRIPTION
## Summary
- Adds `LABEL io.openshift.release.operator=true` to `Dockerfile.ocp` so the image is recognized as an operator image by the OpenShift release controller.

## References
- ocp-build-data config: https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.22/images/aws-node-termination-handler.yml
- [ART-14516](https://issues.redhat.com/browse/ART-14516): https://issues.redhat.com/browse/ART-14516
- [SSE-6709](https://issues.redhat.com/browse/SSE-6709): https://issues.redhat.com/browse/SSE-6709
- [CNTRLPLANE-2602](https://issues.redhat.com/browse/CNTRLPLANE-2602): https://issues.redhat.com/browse/CNTRLPLANE-2602

🤖 Generated with [Claude Code](https://claude.com/claude-code)