### PR TITLE
OCPBUGS-87280: update aws-node-termination-handler-container image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/aws/aws-node-termination-handler
 COPY . .
 RUN CGO_ENABLED=0 go build -mod=vendor -tags nthlinux -ldflags="-s -w" -o /go/bin/node-termination-handler ./cmd/node-termination-handler.go
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/bin/node-termination-handler /usr/bin/
 LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/node-termination-handler"]


### PR DESCRIPTION
Updating aws-node-termination-handler-container image to be consistent with ART for 5.0
__TLDR__:
Product builds by ART can be configured for different base and builder images than corresponding CI
builds. This automated PR requests a change to CI configuration to align with ART's configuration;
please take steps to merge it quickly or contact ART to coordinate changes.

The configuration in the following ART component metadata is driving this alignment request:
[aws-node-termination-handler.yml](https://github.com/openshift-eng/ocp-build-data/tree/53760a5e565d4597ddbddec066e6aa103c27e229/images/aws-node-termination-handler.yml).

__Detail__:

This repository is out of sync with the downstream product builds for this component. The CI
configuration for at least one image differs from ART's expected product configuration. This should
be addressed to ensure that the component's CI testing accurate reflects what customers will
experience.

Most of these PRs are opened as an ART-driven proposal to migrate base image or builder(s) to a
different version, usually prior to GA. The intent is to effect changes in both configurations
simultaneously without breaking either CI or ART builds, so usually ART builds are configured to
consider CI as canonical and attempt to match CI config until the PR merges to align both. ART may
also configure changes in GA releases with CI remaining canonical for a brief grace period to enable
CI to succeed and the alignment PR to merge. In either case, ART configuration will be made
canonical at some point (typically at branch-cut before GA or release dev-cut after GA), so it is
important to align CI configuration as soon as possible.

PRs are also triggered when CI configuration changes without ART coordination, for instance to
change the number of builder images or to use a different golang version. These changes should be
coordinated with ART; whether ART configuration is canonical or not, preferably it would be updated
first to enable the changes to occur simultaneously in both CI and ART at the same time. This also
gives ART a chance to validate the intended changes first. For instance, ART compiles most
components with the Golang version being used by the control plane for a given OpenShift release.
Exceptions to this convention (i.e. you believe your component must be compiled with a Golang
version independent from the control plane) must be granted by the OpenShift staff engineers and
communicated to the ART team.

__Roles & Responsibilities__:
- Component owners are responsible for ensuring these alignment PRs merge with passing
  tests OR that necessary metadata changes are reported to the ART team
  in `#forum-ocp-art` on Slack. If necessary, the changes required by this pull request can be
  introduced with a separate PR opened by the component team. Once the repository is aligned,
  this PR will be closed automatically.
- In particular, it could be that a job like `verify-deps` is complaining. In that case, please open
  a new PR with the dependency issues addressed (and base images bumped). [ART-9595](https://redhat.atlassian.net/browse/ART-9595) for reference.
- Patch-manager or those with sufficient privileges within this repository may add
  any required labels to ensure the PR merges once tests are passing. In cases where ART config is
  canonical, downstream builds are *already* being built with these changes, and merging this PR
  only improves the fidelity of our CI. In cases where ART config is not canonical, this provides
  a grace period for the component team to align their CI with ART's configuration before it becomes
  canonical in product builds.

ART has been configured to reconcile your CI build root image (see https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image).
In order for your upstream .ci-operator.yaml configuration to be honored, you must set the following in your openshift/release ci-operator configuration file:
```
build_root:
  from_repository: true
```

__Change behavior of future PRs__:
* In case you just want to follow the base images that ART suggests, you can configure additional labels to be
  set up automatically. This means that such a PR would *merge without human intervention* (and awareness!) in the future.
  To do so, open a PR to set the `auto_label` attribute in the image configuration. [Example](https://github.com/openshift-eng/ocp-build-data/pull/1778)
* You can set a commit prefix, like `UPSTREAM: <carry>: `. [An example](https://github.com/openshift-eng/ocp-build-data/blob/6831b59dddc5b63282076d3abe04593ad1945148/images/ose-cluster-api.yml#L11).

If you have any questions about this pull request, please reach out in the `#forum-ocp-art` Slack channel.

